### PR TITLE
Dont normalize keys of additions

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -39,6 +39,7 @@ class Configuration implements ConfigurationInterface
                         ->arrayNode('additions')
                             ->info('A list of "key: value" entries that will be set in the [extra] section of each log message (Overwrites existing keys!).')
                             ->useAttributeAsKey('key')
+                            ->normalizeKeys(false)
                             ->prototype('scalar')
                                 ->info('Value for the key.')
                                 ->isRequired()


### PR DESCRIPTION
At @ter-informatique/dev we use OVH Logs Data Platform and we need to send an "addition" with a token but this doesnt work with the bundle.

Example: 

```yaml
hexanet_monolog_extra:
    processor:
        additions:
            X-OVH-TOKEN: '%env(GRAYLOG_OVH_TOKEN)%'
```

Without the PR Symfony normalize `X-OVH-TOKEN` to `X_OVH_TOKEN`. 
The "additions" must not be normalized by Symfony.